### PR TITLE
Changed logic apps to add Service Account as owner at team creation

### DIFF
--- a/Deployment/Scripts/processteamrequestbeta.json
+++ b/Deployment/Scripts/processteamrequestbeta.json
@@ -160,7 +160,7 @@
                                                         "not": {
                                                             "contains": [
                                                                 "@string(body('Get_team_owners'))",
-                                                                "@items('loop_through_members_array')?['MemberUPN']"
+                                                                "@items('Loop_through_Members_array')?['ID']"
                                                             ]
                                                         }
                                                     }
@@ -232,7 +232,7 @@
                                                         "not": {
                                                             "contains": [
                                                                 "@string(body('Get_team_owners'))",
-                                                                "@items('Loop_through_Owners_-_add_to_team')?['OwnerUPN']"
+                                                                "@items('Loop_through_Owners_-_add_to_team')?['ID']"
                                                             ]
                                                         }
                                                     }
@@ -622,6 +622,21 @@
                             },
                             "type": "Scope"
                         },
+                         "Append_service_account_to_Owners_variable": {
+                            "runAfter": {
+                                "Get_service_account_user_profile": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "AppendToArrayVariable",
+                            "inputs": {
+                                "name": "Owners",
+                                "value": {
+                                    "ID": "@{body('Get_service_account_user_profile')?['id']}",
+                                    "OwnerUPN": "@{variables('ServiceAccountUPN')}"
+                                }
+                            }
+                        },
                         "Check_if_SharePoint_site_exists": {
                             "actions": {
                                 "Check_SiteExists_value": {
@@ -965,7 +980,7 @@
                                 }
                             },
                             "runAfter": {
-                                "Get_service_account_user_profile": [
+                                "Append_service_account_to_Owners_variable": [
                                     "Succeeded"
                                 ]
                             },
@@ -1127,7 +1142,7 @@
                                 }
                             },
                             "runAfter": {
-                                "Post_welcome_message": [
+                                "Remove_service_account_from_group": [
                                     "Succeeded"
                                 ]
                             },
@@ -1898,44 +1913,9 @@
                                 }
                             }
                         },
-                        "Post_welcome_message": {
-                            "actions": {
-                                "Add_service_account_to_group": {
-                                    "runAfter": {
-                                    },
-                                    "type": "Http",
-                                    "inputs": {
-                                        "authentication": {
-                                            "audience": "https://graph.microsoft.com",
-                                            "clientId": "@variables('ClientID')",
-                                            "secret": "@variables('ClientSecret')",
-                                            "tenant": "@variables('TenantID')",
-                                            "type": "ActiveDirectoryOAuth"
-                                        },
-                                        "body": {
-                                            "@@odata.id": "https://graph.microsoft.com/v1.0/users/@{body('Get_service_account_user_profile')?['id']}"
-                                        },
-                                        "method": "POST",
-                                        "uri": "@{variables('GraphURL')}/groups/@{body('Parse_created_team_JSON')?['id']}/owners/$ref"
-                                    }
-                                },
-                                "Delay": {
-                                    "runAfter": {
-                                        "Add_service_account_to_group": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "type": "Wait",
-                                    "inputs": {
-                                        "interval": {
-                                            "count": 3,
-                                            "unit": "Minute"
-                                        }
-                                    }
-                                },
                                 "Post_welcome_message_to_general_channel": {
                                     "runAfter": {
-                                        "Delay": [
+                                        "Add_Members_and_Owners": [
                                             "Succeeded"
                                         ]
                                     },
@@ -1974,15 +1954,6 @@
                                         "method": "DELETE",
                                         "uri": "@{variables('GraphURL')}/groups/@{body('Parse_created_team_JSON')?['id']}/owners/@{body('Get_service_account_user_profile')?['id']}/$ref"
                                     }
-                                }
-                            },
-                            "runAfter": {
-                                "Add_Members_and_Owners": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Scope",
-                            "description": "Add the service account to the group/team to post the welcome message, then remove it."
                         },
                         "Send_team_created_email": {
                             "runAfter": {

--- a/Deployment/Scripts/processteamrequestv1.0.json
+++ b/Deployment/Scripts/processteamrequestv1.0.json
@@ -93,6 +93,18 @@
                         }
                     },
                     "actions": {
+                             "Append_service_account_to_Owners_variable": {
+                            "runAfter": {
+                                "Get_service_account_user_profile": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "AppendToArrayVariable",
+                            "inputs": {
+                                "name": "Owners",
+                                "value": "https://graph.microsoft.com/v1.0/users/@{body('Get_service_account_user_profile')?['id']}"
+                            }
+                        },
                         "Check_if_SharePoint_site_exists": {
                             "actions": {
                                 "Check_SiteExists_value": {
@@ -1693,7 +1705,7 @@
                                                                 "description": "@{triggerBody()?['TeamDescription']}",
                                                                 "displayName": "@{triggerBody()?['Title']}",
                                                                 "owners@odata.bind": [
-                                                                    "@{first(variables('Owners'))}"
+                                                                   "@{first(variables('Owners'))}"
                                                                 ],
                                                                 "template@odata.bind": "https://graph.microsoft.com/beta/teamsTemplates('@{triggerBody()?['TemplateId']}')",
                                                                 "visibility": "@{variables('TemplateVisibility')}"
@@ -2208,45 +2220,9 @@
                         },
                         "type": "Foreach"
                     },
-                    "Post_welcome_message": {
-                        "actions": {
-                            "Add_service_account_to_group": {
-                                "runAfter": {
-                                },
-                                "type": "Http",
-                                "inputs": {
-                                    "authentication": {
-                                        "audience": "https://graph.microsoft.com",
-                                        "clientId": "@variables('ClientID')",
-                                        "secret": "@variables('ClientSecret')",
-                                        "tenant": "@variables('TenantID')",
-                                        "type": "ActiveDirectoryOAuth"
-                                    },
-                                    "body": {
-                                        "@@odata.id": "https://graph.microsoft.com/v1.0/users/@{body('Get_service_account_user_profile')?['id']}"
-                                    },
-                                    "method": "POST",
-                                    "uri": "@{variables('GraphURL')}/groups/@{variables('TeamID')}/owners/$ref"
-                                },
-                                "description": "Add service account to the group (team) so we can post the welcome message. We will remove the service account after."
-                            },
-                            "Delay": {
-                                "runAfter": {
-                                    "Add_service_account_to_group": [
-                                        "Succeeded"
-                                    ]
-                                },
-                                "type": "Wait",
-                                "inputs": {
-                                    "interval": {
-                                        "count": 3,
-                                        "unit": "Minute"
-                                    }
-                                }
-                            },
                             "Post_welcome_message_to_general_channel": {
                                 "runAfter": {
-                                    "Delay": [
+                                    "Create_team": [
                                         "Succeeded"
                                     ]
                                 },
@@ -2285,18 +2261,10 @@
                                     "method": "DELETE",
                                     "uri": "@{variables('GraphURL')}/groups/@{variables('TeamID')}/owners/@{body('Get_service_account_user_profile')?['id']}/$ref"
                                 }
-                            }
-                        },
-                        "runAfter": {
-                            "Create_team": [
-                                "Succeeded"
-                            ]
-                        },
-                        "type": "Scope"
-                    },
+                            },
                     "Send_team_created_email": {
                         "runAfter": {
-                            "Post_welcome_message": [
+                            "Remove_service_account_from_group": [
                                 "Succeeded"
                             ]
                         },
@@ -2317,6 +2285,7 @@
                             "path": "/Mail"
                         }
                     },
+                    
                     "Update_status_to_Team_Created": {
                         "runAfter": {
                             "Send_team_created_email": [


### PR DESCRIPTION
Changed both logic apps (v1.0 and beta) to add the Service Account to the Team at the time it is created.

This has been achieved by appending the Service Account to the Owners variable.

This means that the team is created with the Service Account as it's first owner and therefore there is no need to have an extra step to add the account to the team.

This also fixes a potential issue where a delay in synchronizing the Service Account from the unified group over to teams results in a 403 forbidden error when posting the welcome message.