### PR TITLE
Allowing null values for givenName when parsing team owners JSON

### DIFF
--- a/Deployment/Scripts/processteamrequestbeta.json
+++ b/Deployment/Scripts/processteamrequestbeta.json
@@ -364,7 +364,10 @@
                                                             "faxNumber": {
                                                             },
                                                             "givenName": {
-                                                                "type": "string"
+                                                                 "type": [
+                                                                                    "string",
+                                                                                    "null"
+                                                                                ]
                                                             },
                                                             "id": {
                                                                 "type": "string"

--- a/Deployment/Scripts/processteamrequestv1.0.json
+++ b/Deployment/Scripts/processteamrequestv1.0.json
@@ -775,7 +775,10 @@
                                                                             "faxNumber": {
                                                                             },
                                                                             "givenName": {
-                                                                                "type": "string"
+                                                                                 "type": [
+                                                                                    "string",
+                                                                                    "null"
+                                                                                ]
                                                                             },
                                                                             "id": {
                                                                                 "type": "string"


### PR DESCRIPTION
Both logic apps updated to allow null values for the givenName attribute of a user (previous this caused an error when parsing the team owners JSON).