### PR TITLE
Removed unnecessary Graph API permission - User.Invite.All

### DIFF
--- a/Deployment/Scripts/manifest.json
+++ b/Deployment/Scripts/manifest.json
@@ -1,9 +1,9 @@
 [
     {
-        "resourceAppId": "00000002-0000-0000-c000-000000000000",
+        "resourceAppId": "00000003-0000-0ff1-ce00-000000000000",
         "resourceAccess": [
             {
-                "id": "5778995a-e1bf-45b8-affa-663a9f3f4d04",
+                "id": "678536fe-1083-478a-9c59-b99265e6b0d3",
                 "type": "Role"
             }
         ]
@@ -11,10 +11,6 @@
     {
         "resourceAppId": "00000003-0000-0000-c000-000000000000",
         "resourceAccess": [
-            {
-                "id": "09850681-111b-4a89-9bed-3f2cae46d706",
-                "type": "Role"
-            },
             {
                 "id": "741f803b-c850-494e-b5df-cde7c675a1ca",
                 "type": "Role"
@@ -26,10 +22,10 @@
         ]
     },
     {
-        "resourceAppId": "00000003-0000-0ff1-ce00-000000000000",
+        "resourceAppId": "00000002-0000-0000-c000-000000000000",
         "resourceAccess": [
             {
-                "id": "678536fe-1083-478a-9c59-b99265e6b0d3",
+                "id": "5778995a-e1bf-45b8-affa-663a9f3f4d04",
                 "type": "Role"
             }
         ]


### PR DESCRIPTION
Removed an unnecessary Graph API permission from the Azure AD app - User.Invite.All, this was used in a previous iteration of this solution for inviting guest users and is no longer required.