### PR TITLE
Implement Key Vault to store App ID and Secret

### DIFF
--- a/Deployment/Scripts/connections.json
+++ b/Deployment/Scripts/connections.json
@@ -98,6 +98,24 @@
                     "id": "[concat('subscriptions/', parameters('subscriptionId'), '/providers/Microsoft.Web/locations/',parameters('location'),'/managedApis/azureautomation')]"
                 }
             }
+        },
+         {
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2016-06-01",
+            "name": "teamsautomate-kv",
+            "location": "[parameters('location')]",
+            "properties": {
+                "displayName": "Teams Automate - Key Vault",
+                "parameterValues": {
+                    "token:clientId": "[parameters('appId')]",
+                    "token:clientSecret": "[parameters('appSecret')]",
+                    "token:TenantId": "[parameters('tenantId')]",
+                    "token:grantType": "client_credentials"
+                },
+                "api": {
+                    "id": "[concat('subscriptions/', parameters('subscriptionId'), '/providers/Microsoft.Web/locations/',parameters('location'),'/managedApis/keyvault')]"
+                }
+            }
         }
     ]
 }

--- a/Deployment/Scripts/connections.json
+++ b/Deployment/Scripts/connections.json
@@ -21,6 +21,10 @@
         "location": {
             "defaultvalue": "",
             "type": "string"
+        },
+         "keyvaultName": {
+            "defaultvalue": "",
+            "type": "string"
         }
     },
     "resources": [
@@ -107,6 +111,7 @@
             "properties": {
                 "displayName": "Teams Automate - Key Vault",
                 "parameterValues": {
+                    "vaultName": "[parameters('keyvaultName')]",
                     "token:clientId": "[parameters('appId')]",
                     "token:clientSecret": "[parameters('appSecret')]",
                     "token:TenantId": "[parameters('tenantId')]",

--- a/Deployment/Scripts/processteamrequestv1.0.json
+++ b/Deployment/Scripts/processteamrequestv1.0.json
@@ -172,8 +172,8 @@
                                             "inputs": {
                                                 "authentication": {
                                                     "audience": "https://graph.microsoft.com",
-                                                    "clientId": "@variables('ClientID')",
-                                                    "secret": "@variables('ClientSecret')",
+                                                     "clientId": "@body('Get_Client_ID')?['value']",
+                                                    "secret": "@body('Get_Client_Secret')?['value']",
                                                     "tenant": "@variables('TenantID')",
                                                     "type": "ActiveDirectoryOAuth"
                                                 },
@@ -254,7 +254,10 @@
                                                                         "items": {
                                                                             "type": "string"
                                                                         },
-                                                                        "type": "array"
+                                                                        "type": [
+                                                                            "array",
+                                                                            "null"
+                                                                        ]
                                                                     },
                                                                     "deletedDateTime": {
                                                                         "type": "string"
@@ -491,8 +494,8 @@
                                                     "inputs": {
                                                         "authentication": {
                                                             "audience": "https://graph.microsoft.com",
-                                                            "clientId": "@variables('ClientID')",
-                                                            "secret": "@variables('ClientSecret')",
+                                                                "clientId": "@body('Get_Client_ID')?['value']",
+                                                            "secret": "@body('Get_Client_Secret')?['value']",
                                                             "tenant": "@variables('TenantID')",
                                                             "type": "ActiveDirectoryOAuth"
                                                         },
@@ -515,8 +518,8 @@
                                                                     "inputs": {
                                                                         "authentication": {
                                                                             "audience": "https://graph.microsoft.com",
-                                                                            "clientId": "@variables('ClientID')",
-                                                                            "secret": "@variables('ClientSecret')",
+                                                                             "clientId": "@body('Get_Client_ID')?['value']",
+                                                                            "secret": "@body('Get_Client_Secret')?['value']",
                                                                             "tenant": "@variables('TenantID')",
                                                                             "type": "ActiveDirectoryOAuth"
                                                                         },
@@ -596,8 +599,8 @@
                                                                     "inputs": {
                                                                         "authentication": {
                                                                             "audience": "https://graph.microsoft.com",
-                                                                            "clientId": "@variables('ClientID')",
-                                                                            "secret": "@variables('ClientSecret')",
+                                                                          "clientId": "@body('Get_Client_ID')?['value']",
+                                                                            "secret": "@body('Get_Client_Secret')?['value']",
                                                                             "tenant": "@variables('TenantID')",
                                                                             "type": "ActiveDirectoryOAuth"
                                                                         },
@@ -986,8 +989,8 @@
                                                                             "inputs": {
                                                                                 "authentication": {
                                                                                     "audience": "https://graph.microsoft.com",
-                                                                                    "clientId": "@variables('ClientID')",
-                                                                                    "secret": "@variables('ClientSecret')",
+                                                                                     "clientId": "@body('Get_Client_ID')?['value']",
+                                                                                    "secret": "@body('Get_Client_Secret')?['value']",
                                                                                     "tenant": "@variables('TenantID')",
                                                                                     "type": "ActiveDirectoryOAuth"
                                                                                 },
@@ -1047,8 +1050,8 @@
                                             "inputs": {
                                                 "authentication": {
                                                     "audience": "https://graph.microsoft.com",
-                                                    "clientId": "@variables('ClientID')",
-                                                    "secret": "@variables('ClientSecret')",
+                                          "clientId": "@body('Get_Client_ID')?['value']",
+                                                    "secret": "@body('Get_Client_Secret')?['value']",
                                                     "tenant": "@variables('TenantID')",
                                                     "type": "ActiveDirectoryOAuth"
                                                 },
@@ -1069,8 +1072,8 @@
                                             "inputs": {
                                                 "authentication": {
                                                     "audience": "https://graph.microsoft.com",
-                                                    "clientId": "@variables('ClientID')",
-                                                    "secret": "@variables('ClientSecret')",
+                                                       "clientId": "@body('Get_Client_ID')?['value']",
+                                                    "secret": "@body('Get_Client_Secret')?['value']",
                                                     "tenant": "@variables('TenantID')",
                                                     "type": "ActiveDirectoryOAuth"
                                                 },
@@ -1384,8 +1387,8 @@
                                             "inputs": {
                                                 "authentication": {
                                                     "audience": "https://graph.microsoft.com",
-                                                    "clientId": "@variables('ClientID')",
-                                                    "secret": "@variables('ClientSecret')",
+                                              "clientId": "@body('Get_Client_ID')?['value']",
+                                                            "secret": "@body('Get_Client_Secret')?['value']",
                                                     "tenant": "@variables('TenantID')",
                                                     "type": "ActiveDirectoryOAuth"
                                                 },
@@ -1602,8 +1605,8 @@
                                             "inputs": {
                                                 "authentication": {
                                                     "audience": "https://graph.microsoft.com",
-                                                    "clientId": "@variables('ClientID')",
-                                                    "secret": "@variables('ClientSecret')",
+                                                    "clientId": "@body('Get_Client_ID')?['value']",
+                                                            "secret": "@body('Get_Client_Secret')?['value']",
                                                     "tenant": "@variables('TenantID')",
                                                     "type": "ActiveDirectoryOAuth"
                                                 },
@@ -1698,8 +1701,8 @@
                                                         "inputs": {
                                                             "authentication": {
                                                                 "audience": "https://graph.microsoft.com",
-                                                                "clientId": "@variables('ClientID')",
-                                                                "secret": "@variables('ClientSecret')",
+                                                                "clientId": "@body('Get_Client_ID')?['value']",
+                                                                "secret": "@body('Get_Client_Secret')?['value']",
                                                                 "tenant": "@variables('TenantID')",
                                                                 "type": "ActiveDirectoryOAuth"
                                                             },
@@ -1761,8 +1764,8 @@
                                             "inputs": {
                                                 "authentication": {
                                                     "audience": "https://graph.microsoft.com",
-                                                    "clientId": "@variables('ClientID')",
-                                                    "secret": "@variables('ClientSecret')",
+                                                    "clientId": "@body('Get_Client_ID')?['value']",
+                                                        "secret": "@body('Get_Client_Secret')?['value']",
                                                     "tenant": "@variables('TenantID')",
                                                     "type": "ActiveDirectoryOAuth"
                                                 },
@@ -1855,9 +1858,61 @@
                         },
                         "type": "Scope"
                     },
+                     "Get_Client_ID": {
+                            "runAfter": {
+                                "Initialize_TemplateVisibility_variable": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "ApiConnection",
+                            "inputs": {
+                                "host": {
+                                    "connection": {
+                                        "name": "@parameters('$connections')['keyvault']['connectionId']"
+                                    }
+                                },
+                                "method": "get",
+                                "path": "/secrets/@{encodeURIComponent('requestateam-appid')}/value"
+                            },
+                            "description": "Get Azure ad app client id from key vault.",
+                            "runtimeConfiguration": {
+                                "secureData": {
+                                    "properties": [
+                                        "inputs",
+                                        "outputs"
+                                    ]
+                                }
+                            }
+                        },
+                            "Get_Client_Secret": {
+                            "runAfter": {
+                                "Get_Client_ID": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "ApiConnection",
+                            "inputs": {
+                                "host": {
+                                    "connection": {
+                                        "name": "@parameters('$connections')['keyvault']['connectionId']"
+                                    }
+                                },
+                                "method": "get",
+                                "path": "/secrets/@{encodeURIComponent('requestateam-appsecret')}/value"
+                            },
+                            "description": "Get Azure ad app secret from key vault.",
+                            "runtimeConfiguration": {
+                                "secureData": {
+                                    "properties": [
+                                        "inputs",
+                                        "outputs"
+                                    ]
+                                }
+                            }
+                        },
                     "Get_service_account_user_profile": {
                         "runAfter": {
-                            "Initialize_TemplateVisibility_variable": [
+                            "Get_Client_Secret": [
                                 "Succeeded"
                             ]
                         },
@@ -1905,43 +1960,9 @@
                             ]
                         }
                     },
-                    "Initialize_ClientID_variable": {
-                        "runAfter": {
-                            "Initialize_TenantID_variable": [
-                                "Succeeded"
-                            ]
-                        },
-                        "type": "InitializeVariable",
-                        "inputs": {
-                            "variables": [
-                                {
-                                    "name": "ClientID",
-                                    "type": "String",
-                                    "value": "[parameters('appId')]"
-                                }
-                            ]
-                        }
-                    },
-                    "Initialize_ClientSecret_variable": {
-                        "runAfter": {
-                            "Initialize_ClientID_variable": [
-                                "Succeeded"
-                            ]
-                        },
-                        "type": "InitializeVariable",
-                        "inputs": {
-                            "variables": [
-                                {
-                                    "name": "ClientSecret",
-                                    "type": "String",
-                                    "value": "[parameters('appSecret')]"
-                                }
-                            ]
-                        }
-                    },
                     "Initialize_GraphURL_variable": {
                         "runAfter": {
-                            "Initialize_ClientSecret_variable": [
+                            "Initialize_TenantID_variable": [
                                 "Succeeded"
                             ]
                         },
@@ -2256,8 +2277,8 @@
                                 "inputs": {
                                     "authentication": {
                                         "audience": "https://graph.microsoft.com",
-                                        "clientId": "@variables('ClientID')",
-                                        "secret": "@variables('ClientSecret')",
+                                     "clientId": "@body('Get_Client_ID')?['value']",
+                                    "secret": "@body('Get_Client_Secret')?['value']",
                                         "tenant": "@variables('TenantID')",
                                         "type": "ActiveDirectoryOAuth"
                                     },
@@ -2345,6 +2366,11 @@
                             "connectionName": "teamsautomate-automation",
                             "id": "[concat('/subscriptions/',parameters('subscriptionId'),'/providers/Microsoft.Web/locations/',parameters('location'),'/managedApis/azureautomation')]"
                         },
+                           "keyvault": {
+                            "connectionId": "[concat('/subscriptions/',parameters('subscriptionId'),'/resourceGroups/',parameters('resourceGroupName'),'/providers/Microsoft.Web/connections/teamsautomate-kv')]",
+                                "connectionName": "keyvault",
+                                 "id": "[concat('/subscriptions/',parameters('subscriptionId'),'/providers/Microsoft.Web/locations/',parameters('location'),'/managedApis/keyvault')]"
+                            },
                         "office365": {
                             "connectionId": "[concat('/subscriptions/',parameters('subscriptionId'),'/resourceGroups/',parameters('resourceGroupName'),'/providers/Microsoft.Web/connections/teamsautomate-o365outlook')]",
                             "connectionName": "teamsautomate-o365outlook",

--- a/Deployment/Scripts/processteamrequestv1.0.json
+++ b/Deployment/Scripts/processteamrequestv1.0.json
@@ -1872,7 +1872,7 @@
                                     }
                                 },
                                 "method": "get",
-                                "path": "/secrets/@{encodeURIComponent('requestateam-appid')}/value"
+                                "path": "/secrets/@{encodeURIComponent('appid')}/value"
                             },
                             "description": "Get Azure ad app client id from key vault.",
                             "runtimeConfiguration": {
@@ -1898,7 +1898,7 @@
                                     }
                                 },
                                 "method": "get",
-                                "path": "/secrets/@{encodeURIComponent('requestateam-appsecret')}/value"
+                                "path": "/secrets/@{encodeURIComponent('appsecret')}/value"
                             },
                             "description": "Get Azure ad app secret from key vault.",
                             "runtimeConfiguration": {


### PR DESCRIPTION
A Key Vault is now provisioned by the deployment script containing two secrets - Azure AD app ID and secret. If the Key Vault already exists, the secret values are updated.

The Logic App has been updated to no longer store the app id and secret in plain text and instead retrieve these from key vault. The output of the key vault actions in the Logic App has been set to be secure so the values are not displayed in the run history.

The Key Vault is prefixed by part of the tenant name where the deployment script is being ran (first 7 characters), this is to ensure it is unique as all key vaults must have a unique name.