### PR TITLE
Implement keyvault

### DIFF
--- a/Deployment/Scripts/connections.json
+++ b/Deployment/Scripts/connections.json
@@ -98,6 +98,24 @@
                     "id": "[concat('subscriptions/', parameters('subscriptionId'), '/providers/Microsoft.Web/locations/',parameters('location'),'/managedApis/azureautomation')]"
                 }
             }
+        },
+         {
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2016-06-01",
+            "name": "teamsautomate-kv",
+            "location": "[parameters('location')]",
+            "properties": {
+                "displayName": "Teams Automate - Key Vault",
+                "parameterValues": {
+                    "token:clientId": "[parameters('appId')]",
+                    "token:clientSecret": "[parameters('appSecret')]",
+                    "token:TenantId": "[parameters('tenantId')]",
+                    "token:grantType": "client_credentials"
+                },
+                "api": {
+                    "id": "[concat('subscriptions/', parameters('subscriptionId'), '/providers/Microsoft.Web/locations/',parameters('location'),'/managedApis/keyvault')]"
+                }
+            }
         }
     ]
 }

--- a/Deployment/Scripts/connections.json
+++ b/Deployment/Scripts/connections.json
@@ -21,6 +21,10 @@
         "location": {
             "defaultvalue": "",
             "type": "string"
+        },
+         "keyvaultName": {
+            "defaultvalue": "",
+            "type": "string"
         }
     },
     "resources": [
@@ -107,6 +111,7 @@
             "properties": {
                 "displayName": "Teams Automate - Key Vault",
                 "parameterValues": {
+                    "vaultName": "[parameters('keyvaultName')]",
                     "token:clientId": "[parameters('appId')]",
                     "token:clientSecret": "[parameters('appSecret')]",
                     "token:TenantId": "[parameters('tenantId')]",

--- a/Deployment/Scripts/processteamrequestbeta.json
+++ b/Deployment/Scripts/processteamrequestbeta.json
@@ -98,8 +98,8 @@
                                     "inputs": {
                                         "authentication": {
                                             "audience": "https://graph.microsoft.com",
-                                            "clientId": "@variables('ClientID')",
-                                            "secret": "@variables('ClientSecret')",
+                                        "clientId": "@body('Get_Client_ID')?['value']",
+                                            "secret": "@body('Get_Client_Secret')?['value']",
                                             "tenant": "@variables('TenantID')",
                                             "type": "ActiveDirectoryOAuth"
                                         },
@@ -122,8 +122,8 @@
                                                     "inputs": {
                                                         "authentication": {
                                                             "audience": "https://graph.microsoft.com",
-                                                            "clientId": "@variables('ClientID')",
-                                                            "secret": "@variables('ClientSecret')",
+                                                    "clientId": "@body('Get_Client_ID')?['value']",
+                                                            "secret": "@body('Get_Client_Secret')?['value']",
                                                             "tenant": "@variables('TenantID')",
                                                             "type": "ActiveDirectoryOAuth"
                                                         },
@@ -194,8 +194,8 @@
                                                     "inputs": {
                                                         "authentication": {
                                                             "audience": "https://graph.microsoft.com",
-                                                            "clientId": "@variables('ClientID')",
-                                                            "secret": "@variables('ClientSecret')",
+                                                        "clientId": "@body('Get_Client_ID')?['value']",
+                                                            "secret": "@body('Get_Client_Secret')?['value']",
                                                             "tenant": "@variables('TenantID')",
                                                             "type": "ActiveDirectoryOAuth"
                                                         },
@@ -574,8 +574,8 @@
                                                             "inputs": {
                                                                 "authentication": {
                                                                     "audience": "https://graph.microsoft.com",
-                                                                    "clientId": "@variables('ClientID')",
-                                                                    "secret": "@variables('ClientSecret')",
+                                                             "clientId": "@body('Get_Client_ID')?['value']",
+                                                                    "secret": "@body('Get_Client_Secret')?['value']",
                                                                     "tenant": "@variables('TenantID')",
                                                                     "type": "ActiveDirectoryOAuth"
                                                                 },
@@ -707,8 +707,8 @@
                                             "inputs": {
                                                 "authentication": {
                                                     "audience": "https://graph.microsoft.com",
-                                                    "clientId": "@variables('ClientID')",
-                                                    "secret": "@variables('ClientSecret')",
+                                         "clientId": "@body('Get_Client_ID')?['value']",
+                                                    "secret": "@body('Get_Client_Secret')?['value']",
                                                     "tenant": "@variables('TenantID')",
                                                     "type": "ActiveDirectoryOAuth"
                                                 },
@@ -1001,8 +1001,8 @@
                                             "inputs": {
                                                 "authentication": {
                                                     "audience": "https://graph.microsoft.com",
-                                                    "clientId": "@variables('ClientID')",
-                                                    "secret": "@variables('ClientSecret')",
+                                                     "clientId": "@body('Get_Client_ID')?['value']",
+                                                    "secret": "@body('Get_Client_Secret')?['value']",
                                                     "tenant": "@variables('TenantID')",
                                                     "type": "ActiveDirectoryOAuth"
                                                 },
@@ -1025,8 +1025,8 @@
                                                             "inputs": {
                                                                 "authentication": {
                                                                     "audience": "https://graph.microsoft.com",
-                                                                    "clientId": "@variables('ClientID')",
-                                                                    "secret": "@variables('ClientSecret')",
+                                                                 "clientId": "@body('Get_Client_ID')?['value']",
+                                                                    "secret": "@body('Get_Client_Secret')?['value']",
                                                                     "tenant": "@variables('TenantID')",
                                                                     "type": "ActiveDirectoryOAuth"
                                                                 },
@@ -1163,8 +1163,8 @@
                                             "inputs": {
                                                 "authentication": {
                                                     "audience": "https://graph.microsoft.com",
-                                                    "clientId": "@variables('ClientID')",
-                                                    "secret": "@variables('ClientSecret')",
+                                                "clientId": "@body('Get_Client_ID')?['value']",
+                                                    "secret": "@body('Get_Client_Secret')?['value']",
                                                     "tenant": "@variables('TenantID')",
                                                     "type": "ActiveDirectoryOAuth"
                                                 },
@@ -1210,8 +1210,8 @@
                                                 "inputs": {
                                                     "authentication": {
                                                         "audience": "https://graph.microsoft.com",
-                                                        "clientId": "@variables('ClientID')",
-                                                        "secret": "@variables('ClientSecret')",
+                                                  "clientId": "@body('Get_Client_ID')?['value']",
+                                                        "secret": "@body('Get_Client_Secret')?['value']",
                                                         "tenant": "@variables('TenantID')",
                                                         "type": "ActiveDirectoryOAuth"
                                                     },
@@ -1268,8 +1268,8 @@
                                     "inputs": {
                                         "authentication": {
                                             "audience": "https://graph.microsoft.com",
-                                            "clientId": "@variables('ClientID')",
-                                            "secret": "@variables('ClientSecret')",
+                                           "clientId": "@body('Get_Client_ID')?['value']",
+                                            "secret": "@body('Get_Client_Secret')?['value']",
                                             "tenant": "@variables('TenantID')",
                                             "type": "ActiveDirectoryOAuth"
                                         },
@@ -1290,8 +1290,8 @@
                                     "inputs": {
                                         "authentication": {
                                             "audience": "https://graph.microsoft.com",
-                                            "clientId": "@variables('ClientID')",
-                                            "secret": "@variables('ClientSecret')",
+                                          "clientId": "@body('Get_Client_ID')?['value']",
+                                            "secret": "@body('Get_Client_Secret')?['value']",
                                             "tenant": "@variables('TenantID')",
                                             "type": "ActiveDirectoryOAuth"
                                         },
@@ -1554,9 +1554,45 @@
                             },
                             "type": "Scope"
                         },
-                        "Get_service_account_user_profile": {
+                              "Get_Client_ID": {
                             "runAfter": {
                                 "Initialize_ServiceAccountUPN_variable": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "ApiConnection",
+                            "inputs": {
+                                "host": {
+                                    "connection": {
+                                        "name": "@parameters('$connections')['keyvault']['connectionId']"
+                                    }
+                                },
+                                "method": "get",
+                                "path": "/secrets/@{encodeURIComponent('appid')}/value"
+                            },
+                            "description": "Get Azure ad app client id from key vault."
+                        },
+                                "Get_Client_Secret": {
+                            "runAfter": {
+                                "Get_Client_ID": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "ApiConnection",
+                            "inputs": {
+                                "host": {
+                                    "connection": {
+                                        "name": "@parameters('$connections')['keyvault_']['connectionId']"
+                                    }
+                                },
+                                "method": "get",
+                                "path": "/secrets/@{encodeURIComponent('appsecret')}/value"
+                            },
+                            "description": "Get Azure ad app client id from key vault."
+                        },
+                        "Get_service_account_user_profile": {
+                            "runAfter": {
+                                "Get_Client_Secret": [
                                     "Succeeded"
                                 ]
                             },
@@ -1587,43 +1623,9 @@
                                 ]
                             }
                         },
-                        "Initialize_ClientID_variable": {
-                            "runAfter": {
-                                "Initialize_TenantID_variable": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "ClientID",
-                                        "type": "String",
-                                        "value": "[parameters('appId')]"
-                                    }
-                                ]
-                            }
-                        },
-                        "Initialize_ClientSecret_variable": {
-                            "runAfter": {
-                                "Initialize_ClientID_variable": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "ClientSecret",
-                                        "type": "String",
-                                        "value": "[parameters('appSecret')]"
-                                    }
-                                ]
-                            }
-                        },
                         "Initialize_GraphURL_variable": {
                             "runAfter": {
-                                "Initialize_ClientSecret_variable": [
+                                "Initialize_TenantID_variable": [
                                     "Succeeded"
                                 ]
                             },
@@ -1949,8 +1951,8 @@
                                     "inputs": {
                                         "authentication": {
                                             "audience": "https://graph.microsoft.com",
-                                            "clientId": "@variables('ClientID')",
-                                            "secret": "@variables('ClientSecret')",
+                                          "clientId": "@body('Get_Client_ID')?['value']",
+                                    "secret": "@body('Get_Client_Secret')?['value']",
                                             "tenant": "@variables('TenantID')",
                                             "type": "ActiveDirectoryOAuth"
                                         },
@@ -2036,6 +2038,11 @@
                                 "connectionId": "[concat('/subscriptions/',parameters('subscriptionId'),'/resourceGroups/',parameters('resourceGroupName'),'/providers/Microsoft.Web/connections/teamsautomate-automation')]",
                                 "connectionName": "teamsautomate-automation",
                                 "id": "[concat('/subscriptions/',parameters('subscriptionId'),'/providers/Microsoft.Web/locations/',parameters('location'),'/managedApis/azureautomation')]"
+                            },
+                                       "keyvault": {
+                            "connectionId": "[concat('/subscriptions/',parameters('subscriptionId'),'/resourceGroups/',parameters('resourceGroupName'),'/providers/Microsoft.Web/connections/teamsautomate-kv')]",
+                                "connectionName": "keyvault",
+                                 "id": "[concat('/subscriptions/',parameters('subscriptionId'),'/providers/Microsoft.Web/locations/',parameters('location'),'/managedApis/keyvault')]"
                             },
                             "office365": {
                                 "connectionId": "[concat('/subscriptions/',parameters('subscriptionId'),'/resourceGroups/',parameters('resourceGroupName'),'/providers/Microsoft.Web/connections/teamsautomate-o365outlook')]",

--- a/Deployment/Scripts/processteamrequestv1.0.json
+++ b/Deployment/Scripts/processteamrequestv1.0.json
@@ -172,8 +172,8 @@
                                             "inputs": {
                                                 "authentication": {
                                                     "audience": "https://graph.microsoft.com",
-                                                    "clientId": "@variables('ClientID')",
-                                                    "secret": "@variables('ClientSecret')",
+                                                     "clientId": "@body('Get_Client_ID')?['value']",
+                                                    "secret": "@body('Get_Client_Secret')?['value']",
                                                     "tenant": "@variables('TenantID')",
                                                     "type": "ActiveDirectoryOAuth"
                                                 },
@@ -254,7 +254,10 @@
                                                                         "items": {
                                                                             "type": "string"
                                                                         },
-                                                                        "type": "array"
+                                                                        "type": [
+                                                                            "array",
+                                                                            "null"
+                                                                        ]
                                                                     },
                                                                     "deletedDateTime": {
                                                                         "type": "string"
@@ -491,8 +494,8 @@
                                                     "inputs": {
                                                         "authentication": {
                                                             "audience": "https://graph.microsoft.com",
-                                                            "clientId": "@variables('ClientID')",
-                                                            "secret": "@variables('ClientSecret')",
+                                                                "clientId": "@body('Get_Client_ID')?['value']",
+                                                            "secret": "@body('Get_Client_Secret')?['value']",
                                                             "tenant": "@variables('TenantID')",
                                                             "type": "ActiveDirectoryOAuth"
                                                         },
@@ -515,8 +518,8 @@
                                                                     "inputs": {
                                                                         "authentication": {
                                                                             "audience": "https://graph.microsoft.com",
-                                                                            "clientId": "@variables('ClientID')",
-                                                                            "secret": "@variables('ClientSecret')",
+                                                                             "clientId": "@body('Get_Client_ID')?['value']",
+                                                                            "secret": "@body('Get_Client_Secret')?['value']",
                                                                             "tenant": "@variables('TenantID')",
                                                                             "type": "ActiveDirectoryOAuth"
                                                                         },
@@ -596,8 +599,8 @@
                                                                     "inputs": {
                                                                         "authentication": {
                                                                             "audience": "https://graph.microsoft.com",
-                                                                            "clientId": "@variables('ClientID')",
-                                                                            "secret": "@variables('ClientSecret')",
+                                                                          "clientId": "@body('Get_Client_ID')?['value']",
+                                                                            "secret": "@body('Get_Client_Secret')?['value']",
                                                                             "tenant": "@variables('TenantID')",
                                                                             "type": "ActiveDirectoryOAuth"
                                                                         },
@@ -986,8 +989,8 @@
                                                                             "inputs": {
                                                                                 "authentication": {
                                                                                     "audience": "https://graph.microsoft.com",
-                                                                                    "clientId": "@variables('ClientID')",
-                                                                                    "secret": "@variables('ClientSecret')",
+                                                                                     "clientId": "@body('Get_Client_ID')?['value']",
+                                                                                    "secret": "@body('Get_Client_Secret')?['value']",
                                                                                     "tenant": "@variables('TenantID')",
                                                                                     "type": "ActiveDirectoryOAuth"
                                                                                 },
@@ -1047,8 +1050,8 @@
                                             "inputs": {
                                                 "authentication": {
                                                     "audience": "https://graph.microsoft.com",
-                                                    "clientId": "@variables('ClientID')",
-                                                    "secret": "@variables('ClientSecret')",
+                                          "clientId": "@body('Get_Client_ID')?['value']",
+                                                    "secret": "@body('Get_Client_Secret')?['value']",
                                                     "tenant": "@variables('TenantID')",
                                                     "type": "ActiveDirectoryOAuth"
                                                 },
@@ -1069,8 +1072,8 @@
                                             "inputs": {
                                                 "authentication": {
                                                     "audience": "https://graph.microsoft.com",
-                                                    "clientId": "@variables('ClientID')",
-                                                    "secret": "@variables('ClientSecret')",
+                                                       "clientId": "@body('Get_Client_ID')?['value']",
+                                                    "secret": "@body('Get_Client_Secret')?['value']",
                                                     "tenant": "@variables('TenantID')",
                                                     "type": "ActiveDirectoryOAuth"
                                                 },
@@ -1384,8 +1387,8 @@
                                             "inputs": {
                                                 "authentication": {
                                                     "audience": "https://graph.microsoft.com",
-                                                    "clientId": "@variables('ClientID')",
-                                                    "secret": "@variables('ClientSecret')",
+                                              "clientId": "@body('Get_Client_ID')?['value']",
+                                                            "secret": "@body('Get_Client_Secret')?['value']",
                                                     "tenant": "@variables('TenantID')",
                                                     "type": "ActiveDirectoryOAuth"
                                                 },
@@ -1602,8 +1605,8 @@
                                             "inputs": {
                                                 "authentication": {
                                                     "audience": "https://graph.microsoft.com",
-                                                    "clientId": "@variables('ClientID')",
-                                                    "secret": "@variables('ClientSecret')",
+                                                    "clientId": "@body('Get_Client_ID')?['value']",
+                                                            "secret": "@body('Get_Client_Secret')?['value']",
                                                     "tenant": "@variables('TenantID')",
                                                     "type": "ActiveDirectoryOAuth"
                                                 },
@@ -1698,8 +1701,8 @@
                                                         "inputs": {
                                                             "authentication": {
                                                                 "audience": "https://graph.microsoft.com",
-                                                                "clientId": "@variables('ClientID')",
-                                                                "secret": "@variables('ClientSecret')",
+                                                                "clientId": "@body('Get_Client_ID')?['value']",
+                                                                "secret": "@body('Get_Client_Secret')?['value']",
                                                                 "tenant": "@variables('TenantID')",
                                                                 "type": "ActiveDirectoryOAuth"
                                                             },
@@ -1761,8 +1764,8 @@
                                             "inputs": {
                                                 "authentication": {
                                                     "audience": "https://graph.microsoft.com",
-                                                    "clientId": "@variables('ClientID')",
-                                                    "secret": "@variables('ClientSecret')",
+                                                    "clientId": "@body('Get_Client_ID')?['value']",
+                                                        "secret": "@body('Get_Client_Secret')?['value']",
                                                     "tenant": "@variables('TenantID')",
                                                     "type": "ActiveDirectoryOAuth"
                                                 },
@@ -1855,9 +1858,61 @@
                         },
                         "type": "Scope"
                     },
+                     "Get_Client_ID": {
+                            "runAfter": {
+                                "Initialize_TemplateVisibility_variable": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "ApiConnection",
+                            "inputs": {
+                                "host": {
+                                    "connection": {
+                                        "name": "@parameters('$connections')['keyvault']['connectionId']"
+                                    }
+                                },
+                                "method": "get",
+                                "path": "/secrets/@{encodeURIComponent('requestateam-appid')}/value"
+                            },
+                            "description": "Get Azure ad app client id from key vault.",
+                            "runtimeConfiguration": {
+                                "secureData": {
+                                    "properties": [
+                                        "inputs",
+                                        "outputs"
+                                    ]
+                                }
+                            }
+                        },
+                            "Get_Client_Secret": {
+                            "runAfter": {
+                                "Get_Client_ID": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "ApiConnection",
+                            "inputs": {
+                                "host": {
+                                    "connection": {
+                                        "name": "@parameters('$connections')['keyvault']['connectionId']"
+                                    }
+                                },
+                                "method": "get",
+                                "path": "/secrets/@{encodeURIComponent('requestateam-appsecret')}/value"
+                            },
+                            "description": "Get Azure ad app secret from key vault.",
+                            "runtimeConfiguration": {
+                                "secureData": {
+                                    "properties": [
+                                        "inputs",
+                                        "outputs"
+                                    ]
+                                }
+                            }
+                        },
                     "Get_service_account_user_profile": {
                         "runAfter": {
-                            "Initialize_TemplateVisibility_variable": [
+                            "Get_Client_Secret": [
                                 "Succeeded"
                             ]
                         },
@@ -1905,43 +1960,9 @@
                             ]
                         }
                     },
-                    "Initialize_ClientID_variable": {
-                        "runAfter": {
-                            "Initialize_TenantID_variable": [
-                                "Succeeded"
-                            ]
-                        },
-                        "type": "InitializeVariable",
-                        "inputs": {
-                            "variables": [
-                                {
-                                    "name": "ClientID",
-                                    "type": "String",
-                                    "value": "[parameters('appId')]"
-                                }
-                            ]
-                        }
-                    },
-                    "Initialize_ClientSecret_variable": {
-                        "runAfter": {
-                            "Initialize_ClientID_variable": [
-                                "Succeeded"
-                            ]
-                        },
-                        "type": "InitializeVariable",
-                        "inputs": {
-                            "variables": [
-                                {
-                                    "name": "ClientSecret",
-                                    "type": "String",
-                                    "value": "[parameters('appSecret')]"
-                                }
-                            ]
-                        }
-                    },
                     "Initialize_GraphURL_variable": {
                         "runAfter": {
-                            "Initialize_ClientSecret_variable": [
+                            "Initialize_TenantID_variable": [
                                 "Succeeded"
                             ]
                         },
@@ -2256,8 +2277,8 @@
                                 "inputs": {
                                     "authentication": {
                                         "audience": "https://graph.microsoft.com",
-                                        "clientId": "@variables('ClientID')",
-                                        "secret": "@variables('ClientSecret')",
+                                     "clientId": "@body('Get_Client_ID')?['value']",
+                                    "secret": "@body('Get_Client_Secret')?['value']",
                                         "tenant": "@variables('TenantID')",
                                         "type": "ActiveDirectoryOAuth"
                                     },
@@ -2345,6 +2366,11 @@
                             "connectionName": "teamsautomate-automation",
                             "id": "[concat('/subscriptions/',parameters('subscriptionId'),'/providers/Microsoft.Web/locations/',parameters('location'),'/managedApis/azureautomation')]"
                         },
+                           "keyvault": {
+                            "connectionId": "[concat('/subscriptions/',parameters('subscriptionId'),'/resourceGroups/',parameters('resourceGroupName'),'/providers/Microsoft.Web/connections/teamsautomate-kv')]",
+                                "connectionName": "keyvault",
+                                 "id": "[concat('/subscriptions/',parameters('subscriptionId'),'/providers/Microsoft.Web/locations/',parameters('location'),'/managedApis/keyvault')]"
+                            },
                         "office365": {
                             "connectionId": "[concat('/subscriptions/',parameters('subscriptionId'),'/resourceGroups/',parameters('resourceGroupName'),'/providers/Microsoft.Web/connections/teamsautomate-o365outlook')]",
                             "connectionName": "teamsautomate-o365outlook",

--- a/Deployment/Scripts/processteamrequestv1.0.json
+++ b/Deployment/Scripts/processteamrequestv1.0.json
@@ -1872,7 +1872,7 @@
                                     }
                                 },
                                 "method": "get",
-                                "path": "/secrets/@{encodeURIComponent('requestateam-appid')}/value"
+                                "path": "/secrets/@{encodeURIComponent('appid')}/value"
                             },
                             "description": "Get Azure ad app client id from key vault.",
                             "runtimeConfiguration": {
@@ -1898,7 +1898,7 @@
                                     }
                                 },
                                 "method": "get",
-                                "path": "/secrets/@{encodeURIComponent('requestateam-appsecret')}/value"
+                                "path": "/secrets/@{encodeURIComponent('appsecret')}/value"
                             },
                             "description": "Get Azure ad app secret from key vault.",
                             "runtimeConfiguration": {


### PR DESCRIPTION
- Key vault has been now been implemented to store the Azure ad app ID & Secret. These are no longer stored in the Logic Apps as plain text.
- The output of the Key vault actions has been set to be secure so the values cannot be viewed in the run history.
- As key vault names must be globally unique, an additional parameter has been added for the user to specify their own name for the key vault.
- A new function validates if the Key vault already exists in an Azure subscription. If it exists in the current subscription, the user will receive a prompt as to whether they want to use this key vault. If the key vault exists in another subscription they will be required to re-run the script and specify a different name.
- Access policies are configured in the script giving the Azure ad app list/get permissions on the key vault secrets.
- Both the BETA and 1.0 Logic Apps have been updated to support these changes.
