### PR TITLE
Fixing issue with invalid reference to keyvault api connection

### DIFF
--- a/Deployment/Scripts/processteamrequestbeta.json
+++ b/Deployment/Scripts/processteamrequestbeta.json
@@ -1582,7 +1582,7 @@
                             "inputs": {
                                 "host": {
                                     "connection": {
-                                        "name": "@parameters('$connections')['keyvault_']['connectionId']"
+                                        "name": "@parameters('$connections')['keyvault']['connectionId']"
                                     }
                                 },
                                 "method": "get",


### PR DESCRIPTION
Fixed an issue where the beta logic app would fail to deploy as the reference to the key vault api connection contained an underscore.