### PR TITLE
Fixing security issue with redirect url in deployment script

### DIFF
--- a/Deployment/Scripts/deploy.ps1
+++ b/Deployment/Scripts/deploy.ps1
@@ -674,7 +674,7 @@ function AuthoriseLogicAppConnection($resourceId) {
     $parameters = @{
         "parameters" = , @{
             "parameterName" = "token";
-            "redirectUrl"   = "https://ema1.exp.azure.com/ema/default/authredirect"
+            "redirectUrl"   = "http://localhost"
         }
     }
 


### PR DESCRIPTION
Fixing an issue where the redirect url in the AuthoriseLogicAppConnection function (line 677) points to a domain that has potentially been compromised.

There is no evidence to suggest any data sent during the running of the deployment script is compromised but to be safe the redirect url is being set to localhost.