### PR TITLE
Fix schema for users with null as surname value

### DIFF
--- a/Deployment/Scripts/processteamrequestbeta.json
+++ b/Deployment/Scripts/processteamrequestbeta.json
@@ -534,9 +534,7 @@
                                                             },
                                                             "streetAddress": {
                                                             },
-                                                            "surname": {
-                                                                "type": "string"
-                                                            },
+                                                            "surname": { },
                                                             "usageLocation": {
                                                                 "type": "string"
                                                             },


### PR DESCRIPTION
The entire schema for this Parse action could be reduced to just the essential id, upn and email