### PR TITLE
Update to install maximum version 3.23.2007.1 of SharePointPnPPowerShell module

### DIFF
--- a/Deployment/Scripts/deploy.ps1
+++ b/Deployment/Scripts/deploy.ps1
@@ -199,7 +199,7 @@ If (-not (Test-Path -Path "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2")) {
 
 # Install required modules
 Install-Module microsoft.online.sharepoint.powershell -Scope CurrentUser
-Install-Module SharePointPnPPowerShellOnline -Scope CurrentUser -MinimumVersion 3.19.2003.0 -Force
+Install-Module SharePointPnPPowerShellOnline -Scope CurrentUser -MaximumVersion 3.23.2007.1 -Force
 Install-Module ImportExcel -Scope CurrentUser
 Install-Module Az -AllowClobber -Scope CurrentUser
 Install-Module AzureADPreview -Scope CurrentUser


### PR DESCRIPTION
Updated deployment script to install 3.23.2007.1 as the maximum version of the PnP PowerShell module.

This will help avoid the bug in the latest PnP module when creating SharePoint sites (app only not supported error). 

This will help those who do not have a newer version of PnP installed. Those who do will need to downgrade still before running the script.