### PR TITLE
Updated version of PnP PS module to 1.3.13-nightly

### DIFF
--- a/Deployment/Scripts/deploy.ps1
+++ b/Deployment/Scripts/deploy.ps1
@@ -198,7 +198,7 @@ If (-not (Test-Path -Path "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2")) {
 
 # Install required modules
 Install-Module microsoft.online.sharepoint.powershell -Scope CurrentUser
-Install-Module PnP.PowerShell -Scope CurrentUser
+Install-Module PnP.PowerShell -AllowPrerelease -MinimumVersion 1.3.13-nightly -MaximumVersion 1.3.13-nightly -Force
 Install-Module ImportExcel -Scope CurrentUser
 Install-Module Az -AllowClobber -Scope CurrentUser
 Install-Module AzureADPreview -Scope CurrentUser


### PR DESCRIPTION
Updated to the 1.3.13 nightly build of PnP PowerShell.

Specifically to address a bug in the previous main release (Access denied error when calling New-PnPSite).