### PR TITLE
Removing dependency on old 1.4.0 PnP module

### DIFF
--- a/Deployment/Scripts/deploy.ps1
+++ b/Deployment/Scripts/deploy.ps1
@@ -246,26 +246,18 @@ function InstallModules ($modules) {
                 if ($spModule) {
                     throw('Please remove the older "SharePointPnPPowerShellOnline" module before the deployment can install the new cross-platform module "PnP.PowerShell"')                    
                 }
-                try {
-                    Write-Host('Installing required PowerShell Module {0}' -f $module) -ForegroundColor Yellow
-                    Install-Module -Name $module -Scope CurrentUser -RequiredVersion "1.4.0" -AllowClobber -Confirm:$false
-                }
-                catch {
-                    throw('Failed to install PowerShell module {0}: {1}' -f $module, $_.Exception.Message)
-                } 
             }
-            else {
-                try {
-                    Write-Host('Install required PowerShell Module {0}' -f $module) -ForegroundColor Yellow
-                    Install-Module -Name $module -Scope CurrentUser -AllowClobber -Confirm:$false
-                }
-                catch {
-                    throw('Failed to install PowerShell module {0}: {1}' -f $module, $_.Exception.Message)
-                } 
+
+            try {
+                Write-Host('Installing required PowerShell Module {0}' -f $module) -ForegroundColor Yellow
+                Install-Module -Name $module -Scope CurrentUser -RequiredVersion "1.4.0" -AllowClobber -Confirm:$false
             }
+            catch {
+                throw('Failed to install PowerShell module {0}: {1}' -f $module, $_.Exception.Message)
+            } 
         }
     }
-
+    
     if ($psTrustDisabled) {
         Set-PSRepository -Name PSGallery -InstallationPolicy Untrusted
     }


### PR DESCRIPTION
Removing old PnP PowerShell version (1.4.0). We had reverted to this one as the newer one had bugs. These appear to be solved so now we are using the latest PnP version available at the time of running the script. 