### PR TITLE
Updates to CLI calls to create/update azure ad app

### DIFF
--- a/Deployment/Scripts/deploy.ps1
+++ b/Deployment/Scripts/deploy.ps1
@@ -802,13 +802,6 @@ Write-Host "Installed modules" -ForegroundColor Green
 
 Write-Ascii -InputObject "Request-a-Team" -ForegroundColor Magenta
 
-# Generate base64 secret for the app
-$guid = New-Guid
-
-$global:appSecret = ([System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(($guid))))
-
-$global:encodedAppSecret = [System.Web.HttpUtility]::UrlEncode($global:appSecret) 
-
 # Initialise connections - Azure Az/CLI
 Write-Host "Launching Azure sign-in..." -ForegroundColor Yellow
 $azConnect = Connect-AzAccount -Subscription $SubscriptionId -Tenant $TenantId


### PR DESCRIPTION
# Pull Request

By submitting this pull request, you agree to the [code of conduct](https://opensource.microsoft.com/codeofconduct/).

Please complete the following table to help us identify the category of this pull request. 

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | Y                                     |
| New feature?    | N                                     |
| Doc fix         | N                                   |

## What's in the Pull Request?

Updated the deployment script Azure CLI cmdlets used to create/update the Azure AD app. The migration of the CLI calls to the Graph API caused issues due to some changes in the cmdlets. Previously we have generated the secret for the app and passed this in during creation, this is now not supported so it has been updated to use the az ad app credential cmdlet to autogenerate a secret once the app is created/updated.
